### PR TITLE
Issue #30: solved?

### DIFF
--- a/turbulence_class.R
+++ b/turbulence_class.R
@@ -118,10 +118,16 @@ dofft <- function(velocity,acq.freq){
   X.k <- fft(velocity)
   peaks <- Mod(X.k)/Npoint
   if(Npoint%%2==0){
+    #cat(paste('Sono nel caso dispari', '\n'))
     Freq1 <- seq(0, acq.freq/2, length.out=length(peaks)/2)
+    #cat(paste('Freq1: ', length(Freq1), '\n'))
     Freq2 <- seq(acq.freq/2-acq.freq/Npoint, 0, length.out=length(peaks)/2)
-    Freq2 <- Freq2[-(length(Freq2)-1)]
+    #cat(paste('Freq2: ', length(Freq2), '\n'))
+    #Freq2 <- Freq2[-(length(Freq2)-1)] # I think it is this to give problems in the even case...
+    # (enable commented cat() to see what's going on)
+    #cat(paste('Freq2: ', length(Freq2), '\n'))
     Freq <- c(Freq1, Freq2)
+    #cat(paste('Freq: ', length(Freq), '\n'))
   }else{
     Freq1 <- seq(0, acq.freq/2, length.out=length(peaks)/2)
     Freq2 <- seq(acq.freq/2, 0, length.out=length(peaks)/2)


### PR DESCRIPTION
Mi riferisco alla issue intitolata "data$freq e data$peaks: lengths different".
Io avevo segnalato problemi con il dataset di Fontanella2, ControlPoint,
20160129.16r (gli altri prima e dopo nel ciclo non mi davano alcun problema).
Ho fatto un po' di controlli (ho controllato le lunghezze di tutti i dataset
in tutti i passaggi, ho fatto un controllo con i dataset convertiti da Mauri etc...),
l'unica cosa che mi è saltata all'occhio è che il dataset su cui avevo i problemi era
l'unico con lunghezza pari.
Essendo che nella fft, quando andiamo a calcolare le frequenze, dividiamo i casi
pari e dispari, ho cercato il problema lì e con un po' di cat mi accorgo che
il problema insorge quando, nel caso pari, andiamo a sovrascrivere Freq2
togliendo un elemento (la lunghezza passa così da pari a dispari).
Provando a commentare funziona tutto.
Io non mi ricordo bene perchè avevamo deciso di togliere l'elemento
(mi ricordo la questione dell'ordinamento, ma non questo nello specifico),
ci ho pensato un po' ma non mi è venuta in mente nessuna ragione particolarmente
valida... probabilmente sbaglio, per ora ho commentato tutto, compreso
i cat usati per la diagnosi, poi buttateci un occhio e se vi sembra che abbia
senso cancelliamo il codice buggato in modo da lasciare quello funzionante
pulito e facciamo una PR.

Poi comunque quella funzione per la fft andrà commentata bene, perchè io ormai sono
vecchio e rincoglionito e un po' ci metto a ricordarmi cosa abbiamo fatto...

 On branch Eugen
 Changes to be committed:
    modified:   turbulence_class.R
