### PR TITLE
Fixato Create-Directory

### DIFF
--- a/functions.R
+++ b/functions.R
@@ -18,7 +18,7 @@ create_directory<-function(path){
     dir.create(path, showWarnings = FALSE, recursive = TRUE)
   }else{
     if(dir.exists(path)!=TRUE){
-      dir.create(path)
+      dir.create(path, showWarnings = FALSE, recursive = TRUE)
     }
     path<-paste(path,'/',sep='')
   }


### PR DESCRIPTION
In create_directory, dir.create veniva chiamata con argomenti diversi
in funzione alla versione di R. Quello che deve cambiare e` solo
l'utilizzo di dir.exist, mentre dir.create deve essere chiamata con
gli stessi argomenti.
